### PR TITLE
Fix hero ability staying deactivated after returning from leave

### DIFF
--- a/app/src/main/java/com/example/cpudefense/Intermezzo.kt
+++ b/app/src/main/java/com/example/cpudefense/Intermezzo.kt
@@ -387,7 +387,7 @@ class Intermezzo(var gameView: GameView): GameElement(), Fadable {
 
     private fun oneHeroMustGoOnLeave(ident: Stage.Identifier): Boolean
     {
-        return (isLevelWhereHeroGoesOnLeave(ident) && (ident.number !in gameView.gameMechanics.holidays))
+        return isLevelWhereHeroGoesOnLeave(ident)
     }
 
     inner class HeroSelection

--- a/app/src/main/java/com/example/cpudefense/activities/GameActivity.kt
+++ b/app/src/main/java/com/example/cpudefense/activities/GameActivity.kt
@@ -356,6 +356,7 @@ class GameActivity : Activity() {
         setGameActivityStatus(GameActivityStatus.PLAYING)
         with (gameMechanics) {
             currentStageIdent = ident
+            currentHeroes(ident).values.forEach { hero -> hero.isOnLeave = hero.isOnLeave(ident) }
             calculateLives()
             calculateStartingCash()
             calculateCoins(nextStage)


### PR DESCRIPTION
Fixes #214. Fixes #210.

Two related bugs in the hero leave system:

**Bug 1 (#214): Hero ability stays disabled after returning from leave**
`hero.isOnLeave` is a cached boolean set at hero creation. In `startNextStage`, `currentStageIdent` was updated to the new level but the cached flag was never refreshed — so a hero whose leave had just ended kept `isOnLeave = true` into the following level. `heroModifier()` reads this cached field, so the hero's effect was skipped even though leave was over.

Fix: refresh `isOnLeave` for all heroes against the new level identifier immediately after `currentStageIdent` is set in `startNextStage`.

---

**Bug 2 (#210): Hero leave selection can be gamed**
The leave assignment was cached permanently — `oneHeroMustGoOnLeave` returned false if a holiday was already stored for the level number. This let players replay a leave level with temporarily manipulated hero upgrade levels to force a specific (undesired) hero into the selection, locking that choice in forever.

Fix: remove the `!in holidays` guard so the selection is always required when entering a leave level, and `addLeave` overwrites any previous assignment.