### PR TITLE
[app] remove useless `+4` in addVehicle

### DIFF
--- a/app/src/main/java/com/example/cpudefense/networkmap/Network.kt
+++ b/app/src/main/java/com/example/cpudefense/networkmap/Network.kt
@@ -216,7 +216,7 @@ class Network(val gameMechanics: GameMechanics, val commonView: CommonView, x: I
 
     fun addVehicle(vehicle: Vehicle)
     /** adds an existing vehicle to the network */
-    {+4
+    {
         vehicles.add(vehicle)
     }
 


### PR DESCRIPTION
This appears to be extraneous and confusing. Remove it
